### PR TITLE
Performance increase to custom placeholders

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -52,7 +52,8 @@ globals = {
   "max",
   "format",
   "UnitFullName",
-
+  "UnitIsConnected",
+  "UnitIsDeadOrGhost",
   -- Locals
   "L",
 }

--- a/PhenomRaidTools/Source/EventHandler.lua
+++ b/PhenomRaidTools/Source/EventHandler.lua
@@ -181,7 +181,6 @@ function EventHandler.StartEncounter(event, encounterID, encounterName)
       if encounter then
         if encounter.enabled then
           PRT.Debug(L["Running PhenomRaidTools version %s"]:format(PRT.HighlightString(PRT.db.profile.version)))
-
           PRT.EnsureEncounterTrigger(encounterVersion)
           PRT.RegisterEvents(EventHandler.trackedInCombatEvents)
           PRT.currentEncounter.encounter = PRT.TableUtils.Clone(encounterVersion)
@@ -190,7 +189,7 @@ function EventHandler.StartEncounter(event, encounterID, encounterName)
           CompileInterestingUnits(PRT.currentEncounter)
           CompileInterestingEvents(PRT.currentEncounter)
           LogInterestingUnitsAndEvents(PRT.currentEncounter)
-
+          PRT.SetupCustomPlaceholders()
           AceTimer:ScheduleRepeatingTimer(PRT.ProcessMessageQueue, 0.5)
 
           -- Make sure timings are once queried at the start so timing with < 0.5s will trigger

--- a/PhenomRaidTools/Source/Utils.lua
+++ b/PhenomRaidTools/Source/Utils.lua
@@ -18,7 +18,7 @@ local classColors = {
 }
 
 -- Create local copies of API functions which we use
-local UnitClass, GetSpellInfo, UnitExists, UnitIsDead, UnitName = UnitClass, GetSpellInfo, UnitExists, UnitIsDead, UnitName
+local UnitClass, GetSpellInfo, UnitExists, UnitIsDead, UnitName, UnitIsConnected, UnitIsDeadOrGhost = UnitClass, GetSpellInfo, UnitExists, UnitIsDead, UnitName, UnitIsConnected, UnitIsDeadOrGhost
 local GetRaidRosterInfo, GetUnitName, GetNumGroupMembers, UnitInParty, UnitInRaid = GetRaidRosterInfo, GetUnitName, GetNumGroupMembers, UnitInParty, UnitInRaid
 
 

--- a/PhenomRaidTools/Source/Utils.lua
+++ b/PhenomRaidTools/Source/Utils.lua
@@ -352,7 +352,7 @@ do
           end
         end
         if not found and lastInPartyButDead then
-          tinsert(t, strtrim(name, " "))
+          tinsert(t, strtrim(lastInPartyButDead, " "))
         end
       end
     end


### PR DESCRIPTION
cache global and encounter specific placeholders on encounter_start, and use that cache to be more efficient when looking for placeholder values, should be big performance increase with larger amount of custom placeholders

also check if unit is connected before adding it to the list, and send notification to dead (or ghost) players when there is no backup who is alive and connected